### PR TITLE
Add Mac OS X support

### DIFF
--- a/portable/apple/apple.h
+++ b/portable/apple/apple.h
@@ -17,3 +17,4 @@
 /* Functions */
 char *fparseln(FILE *, size_t *, size_t *, const char[3], int);
 void *reallocarray(void *, size_t, size_t);
+long long	strtonum(const char *, long long, long long, const char **);

--- a/tags.c
+++ b/tags.c
@@ -8,7 +8,7 @@
 
 #include <sys/queue.h>
 #include <sys/stat.h>
-#if defined(__linux__) || defined(__DragonFly__)
+#if defined(__linux__) || defined(__DragonFly__) || defined(__APPLE__)
 #include "portable/common/tree.h"
 #else
 #include <sys/tree.h>
@@ -24,7 +24,7 @@
 #include <unistd.h>
 #if defined(__linux__) || defined(__CYGWIN__)
 #include "portable/linux/util.h"
-#elif defined(__OpenBSD__) || defined(__NetBSD__)
+#elif defined(__OpenBSD__) || defined(__NetBSD__) || defined(__APPLE__)
 #include <util.h>
 #else
 #include <libutil.h>


### PR DESCRIPTION
- Declare strtonum (in portable/apple/apple.h).
- Use portable/common/tree.h, OS X does not ship with sys/tree.h.
- Use util.h, OS X ships with that instead of libutil.h.
