### PR TITLE
Add Bitrig support.

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -52,7 +52,7 @@ CFLAGS += -D__dead=__dead2 -DLOGIN_NAME_MAX=MAXLOGNAME
 OBJS += portable/common/reallocarray.o
 LIBS += -lutil
 else ifeq ($(UNAME_S),Bitrig)
-$(error Fix your in-base editor)
+$(error Type 'make' instead)
 else ifeq ($(findstring CYGWIN,$(UNAME_S)),CYGWIN)
 CFLAGS += -D_GNU_SOURCE -D__dead="__attribute__((__noreturn__))" -Dst_mtimespec=st_mtim
 OBJS +=	portable/linux/fgetln.o portable/common/fparseln.o \

--- a/tags.c
+++ b/tags.c
@@ -24,7 +24,7 @@
 #include <unistd.h>
 #if defined(__linux__) || defined(__CYGWIN__)
 #include "portable/linux/util.h"
-#elif defined(__OpenBSD__) || defined(__NetBSD__) || defined(__APPLE__)
+#elif defined(__OpenBSD__) || defined(__NetBSD__) || defined(__APPLE__) || defined(__Bitrig__)
 #include <util.h>
 #else
 #include <libutil.h>


### PR DESCRIPTION
Bitrig builds fine with make.

If build is attempted with gmake, tell user to use make
the same way other bsd make platforms work.

Use util.h for Bitrig.
