### PR TITLE
Initialise curmap to silence compiler warning.

### DIFF
--- a/extend.c
+++ b/extend.c
@@ -699,7 +699,7 @@ excline(char *line)
 	char	*argp = NULL;
 	long	 nl;
 	int	 bind;
-	KEYMAP	*curmap;
+	KEYMAP	*curmap = NULL;
 #define BINDARG		0  /* this arg is key to bind (local/global set key) */
 #define	BINDNO		1  /* not binding or non-quoted BINDARG */
 #define BINDNEXT	2  /* next arg " (define-key) */


### PR DESCRIPTION
I'd also propose adding a few more restrictive CFLAGS and trying to clean the codebase up. Is that something you're interested in?
