### PR TITLE
Build with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: c
+os:
+  - linux
+  - osx
+compiler:
+  - clang
+  - gcc
+script: make


### PR DESCRIPTION
This change adds a configuration file for building mg on [Travis](https://travis-ci.org/).
Travis can watch repositories on GitHub and build pushes and pull requests.
This can help ensure that mg stays portable to systems that Travis tests on.

Unfortunately, Travis only offers (Ubuntu) Linux and OS X.
Still, that's better than nothing, and cheaper than buying a Mac. :-)

The configuration builds mg on OS X and Linux, using both GCC and Clang.
It basically runs `make` and succeeds if that does.

Sample output is available [here](https://travis-ci.org/mkhl/mg).
