### PR TITLE
fileio.c: use NAME_MAX instead of MAXNAMLEN.

### DIFF
--- a/fileio.c
+++ b/fileio.c
@@ -492,7 +492,7 @@ make_file_list(char *buf)
 	 * SV files are fairly short.  For BSD, something more general would
 	 * be required.
 	 */
-	if (preflen > NFILEN - MAXNAMLEN)
+	if (preflen > NFILEN - NAME_MAX)
 		return (NULL);
 
 	/* loop over the specified directory, making up the list of files */


### PR DESCRIPTION
NAME_MAX is the POSIX constant; given that this version of mg is
intended to be portable, it makes sense to use it instead of the
BSD-specific MAXNAMLEN.

This fixes #8, pointed out by @arturocastro.

Tested on:
- OpenBSD 5.9 / amd64
- Darwin 14.5.0 (OS X 10.10.5) / x86_64
- Ubuntu 14.04.3 LTS (kernel 3.13.0-36-generic) / x86_64
