### PR TITLE
Fix the build on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,4 @@ compiler:
   - clang
   - gcc
 script: make
+osx_image: xcode6.4

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -39,8 +39,8 @@ OBJS +=	portable/linux/fgetln.o portable/common/fparseln.o \
 	portable/linux/strlcpy.o portable/common/strtonum.o
 else ifeq ($(UNAME_S),Darwin)
 CFLAGS += -DMSG_NOSIGNAL=SO_NOSIGPIPE -DLOGIN_NAME_MAX=MAXLOGNAME
-OBJS += portable/common/fparseln.o portable/common/reallocarray.o \
-	portable/common/strtonum.o
+OBJS += portable/common/fparseln.o portable/common/futimens.o \
+	portable/common/reallocarray.o portable/common/strtonum.o
 LIBS += -lutil
 else ifeq ($(UNAME_S),FreeBSD)
 CFLAGS += -D__dead=__dead2 -DLOGIN_NAME_MAX=MAXLOGNAME

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ All other operating systems should type `make`.
 Testing
 -------
 Tested on recent versions of Arch, Cygwin, Debian, DragonFly BSD, FreeBSD,
-Mac OS X, NetBSD, Slackware, and Ubuntu.
+Mac OS X (10.10 or later), NetBSD, Slackware, and Ubuntu.
 
 Licensing
 ---------

--- a/portable/apple/apple.h
+++ b/portable/apple/apple.h
@@ -14,7 +14,13 @@
 #define FPARSELN_UNESCREST      0x08
 #define FPARSELN_UNESCALL       0x0f
 
+/* struct stat compatibilty */
+#define st_atim st_atimespec
+#define st_mtim st_mtimespec
+#define st_ctim st_ctimespec
+
 /* Functions */
 char *fparseln(FILE *, size_t *, size_t *, const char[3], int);
 void *reallocarray(void *, size_t, size_t);
 long long	strtonum(const char *, long long, long long, const char **);
+int	futimens(int, const struct timespec[2]);

--- a/portable/common/futimens.c
+++ b/portable/common/futimens.c
@@ -1,0 +1,12 @@
+/* This file is in the public domain. */
+
+#include <sys/time.h>
+
+int
+futimens(int fildes, const struct timespec times[2])
+{
+	struct timeval timevals[2];
+	TIMESPEC_TO_TIMEVAL(&timevals[0], &times[0]);
+	TIMESPEC_TO_TIMEVAL(&timevals[1], &times[1]);
+	return futimes(fildes, timevals);
+}


### PR DESCRIPTION
This change:
- aliases `st_{a,m,c}tim` to `st_{a,m,c}timespec`
- reimplements `futimens` by converting `timespec` to `timeval` and calling `futimes`

Closes #11

Open questions:
- [ ] Is `futimes` a sensible replacement for `futimens`?
- [ ] Should the conversions in `futimens` read
  - `TIMESPEC_TO_TIMEVAL(&timevals[1], &times[1])` or
  - `TIMESPEC_TO_TIMEVAL(timevals + 1, times + 1)`?
- [ ] I haven’t included a license/copyright statement to `portable/common/futimens.c`, which kind would you prefer?
