### PR TITLE
Move sys/queue.h additions to a common header.

### DIFF
--- a/def.h
+++ b/def.h
@@ -13,6 +13,7 @@
 /*
  * We open with Mg portable things.
  */
+#include "portable/common/common.h"
 #if defined(__linux__) || defined(__CYGWIN__)
 #include "portable/linux/linux.h"
 #endif

--- a/portable/apple/apple.h
+++ b/portable/apple/apple.h
@@ -19,12 +19,6 @@
 #define st_mtim st_mtimespec
 #define st_ctim st_ctimespec
 
-/* From OpenBSD sys/queue.h */
-#define SLIST_FOREACH_SAFE(var, head, field, tvar)	\
-    for ((var) = SLIST_FIRST(head);			\
-	(var) && ((tvar) = SLIST_NEXT(var, field), 1);	\
-	(var) = (tvar))
-
 /* Functions */
 char *fparseln(FILE *, size_t *, size_t *, const char[3], int);
 void *reallocarray(void *, size_t, size_t);

--- a/portable/common/common.h
+++ b/portable/common/common.h
@@ -1,0 +1,25 @@
+/*
+ * Support for non-OpenBSD systems.
+ */
+
+#ifndef SLIST_FOREACH_SAFE
+/* From OpenBSD sys/queue.h */
+#define SLIST_FOREACH_SAFE(var, head, field, tvar)	\
+    for ((var) = SLIST_FIRST(head);			\
+	(var) && ((tvar) = SLIST_NEXT(var, field), 1);	\
+	(var) = (tvar))
+#endif
+
+#ifndef TAILQ_END
+/* From OpenBSD sys/queue.h */
+#define TAILQ_END(head) NULL
+#endif
+
+#ifndef TAILQ_FOREACH_SAFE
+/* From OpenBSD sys/queue.h */
+#define TAILQ_FOREACH_SAFE(var, head, field, tvar)		\
+  for ((var) = TAILQ_FIRST(head);				\
+       (var) != TAILQ_END(head) &&				\
+       ((tvar) = TAILQ_NEXT(var, field), 1);			\
+       (var) = (tvar))
+#endif

--- a/portable/dragonfly/dragonfly.h
+++ b/portable/dragonfly/dragonfly.h
@@ -8,14 +8,5 @@
 /* Defines */
 #define MAXNAMLEN 255
 
-/* From OpenBSD sys/queue.h */
-#define TAILQ_END(head)	NULL
-
-#define TAILQ_FOREACH_SAFE(var, head, field, tvar)		\
-  for ((var) = TAILQ_FIRST(head);				\
-       (var) != TAILQ_END(head) &&				\
-       ((tvar) = TAILQ_NEXT(var, field), 1);			\
-       (var) = (tvar))
-
 /* Functions */
 void   *reallocarray(void *, size_t, size_t);

--- a/portable/linux/linux.h
+++ b/portable/linux/linux.h
@@ -9,16 +9,6 @@
 
 /* Defines */
 #define TCSASOFT 0
-#define TAILQ_END(head) NULL
-
-/* From OpenBSD sys/queue.h -- not needed on Cygwin */
-#ifdef __linux__
-#define TAILQ_FOREACH_SAFE(var, head, field, tvar)		\
-  for ((var) = TAILQ_FIRST(head);				\
-       (var) != TAILQ_END(head) &&				\
-       ((tvar) = TAILQ_NEXT(var, field), 1);			\
-       (var) = (tvar))
-#endif
 
 /* Functions */
 void	       *reallocarray(void *, size_t, size_t);


### PR DESCRIPTION
Some macros are missing on multiple systems (e.g. neither MacOS X nor
Linux has SLIST_FOREACH_SAFE, now used in dired.c), so this saves
duplicating the definitions in the system-specific headers. They're
guaranteed to be macros, so testing for their existence with #ifdef
should be safe.
