### PR TITLE
New option: disable-newline-prompt.

### DIFF
--- a/def.h
+++ b/def.h
@@ -480,6 +480,7 @@ int		 getxtra(struct list *, struct list *, int, int);
 void		 free_file_list(struct list *);
 
 /* fileio.c */
+int		 nonewlineprompt(int, int);
 int		 ffropen(FILE **, const char *, struct buffer *);
 void		 ffstat(FILE *, struct buffer *);
 int		 ffwopen(FILE **, const char *, struct buffer *);

--- a/fileio.c
+++ b/fileio.c
@@ -33,6 +33,16 @@ static int   bkupleavetmp(const char *);
 static char *bkupdir;
 static int   leavetmp = 0;	/* 1 = leave any '~' files in tmp dir */
 
+static int   shownlprompt = TRUE;
+
+/* Don't check for a newline at the end of a file. */
+int
+nonewlineprompt(int f, int n)
+{
+	shownlprompt = FALSE;
+	return (TRUE);
+}
+
 /*
  * Open a file for reading.
  */
@@ -167,7 +177,7 @@ ffputbuf(FILE *ffp, struct buffer *bp)
 	/*
 	 * XXX should be variable controlled (once we have variables)
 	 */
-	if (llength(lback(lpend)) != 0) {
+	if (shownlprompt && (llength(lback(lpend)) != 0)) {
 		if (eyorn("No newline at end of file, add one") == TRUE) {
 			lnewline_at(lback(lpend), llength(lback(lpend)));
 			putc('\n', ffp);

--- a/funmap.c
+++ b/funmap.c
@@ -83,6 +83,7 @@ static struct funmap functnames[] = {
 	{desckey, "describe-key-briefly",},
 	{diffbuffer, "diff-buffer-with-file",},
 	{digit_argument, "digit-argument",},
+	{nonewlineprompt, "disable-newline-prompt",},
 	{lowerregion, "downcase-region",},
 	{lowerword, "downcase-word",},
 	{showversion, "emacs-version",},


### PR DESCRIPTION
This adds a new command (disable-newline-prompt) that suppresses
the check for a newline at the end of a file when saving.