### PR TITLE
glibc's version of openpty is in libutil

### DIFF
--- a/configure
+++ b/configure
@@ -371,6 +371,7 @@ echo "$os"
 case "x$os" in
   "xLinux"|"xCYGWIN"*)
     cflags="$cflags -D_GNU_SOURCE -D__dead=\"__attribute__((__noreturn__))\" -Dst_mtimespec=st_mtim"
+    libs="$libs -lutil"
     ;;
   "xDarwin")
     cflags="$cflags -DMSG_NOSIGNAL=SO_NOSIGPIPE -DLOGIN_NAME_MAX=MAXLOGNAME"

--- a/main.c
+++ b/main.c
@@ -17,7 +17,7 @@
 #include <termios.h>
 #include <unistd.h>
 #if defined(__linux__) || defined(__CYGWIN__)
-#include "util.h"
+#include <pty.h>
 #elif defined(__OpenBSD__) || defined(__NetBSD__) || defined(__APPLE__)
 #include <util.h>
 #else


### PR DESCRIPTION
The recent set of upstream changes now use openpty in main.c. There's a prototype for this in mg's util.h, but no implementation (and the prototype is slightly different from the glibc one anyway - no consts).

Link with -lutil on Linux and Cygwin, and include <pty.h> rather than util.h in main.c.

I've only tested this on Linux but it looks like it should work the same way on Cygwin. It might be worth cleaning out the stuff in util.h that mg doesn't actually provide at some point...