### PR TITLE
Fix compilation errors with GCC-14

### DIFF
--- a/main.c
+++ b/main.c
@@ -18,6 +18,7 @@
 #include <unistd.h>
 #if defined(__linux__) || defined(__CYGWIN__)
 #include <pty.h>
+#include <utmp.h>
 #elif defined(__OpenBSD__) || defined(__NetBSD__) || defined(__APPLE__)
 #include <util.h>
 #else


### PR DESCRIPTION
OpenWrt (linux-6.1.89, musl-1.2.5)

I had the following error in mg.
```
main.c: In function 'pty_init':
main.c:311:9: error: implicit declaration of function 'login_tty' [-Wimplicit-function-declaration]
  311 |         login_tty(slave);
      |         ^~~~~~~~~
```